### PR TITLE
Installation is broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,5 @@
 /app/cache/*
 /app/logs/*
 
-# Build files
-/app/bootstrap.php.cache
-
 # Configuration files
 app/config/parameters.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes between versions
 
+## 0.2.2: Fix install
+
+* removed `app/bootstrap.php.cache` file
+* added check for database exceptions
+
 ## 0.2.1: Fix dependencies
 
 * removed AsseticBundle

--- a/app/console
+++ b/app/console
@@ -12,7 +12,7 @@
 
 set_time_limit(0);
 
-require_once __DIR__.'/bootstrap.php.cache';
+require_once __DIR__.'/autoload.php';
 require_once __DIR__.'/AppKernel.php';
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -5,7 +5,7 @@
     backupGlobals="false"
     colors="true"
     syntaxCheck="false"
-    bootstrap="bootstrap.php.cache">
+    bootstrap="autoload.php">
 
     <testsuites>
         <testsuite name="Functional Test Suite">

--- a/src/TempoSimple/Bundle/SpaghettiBundle/Command/PunchTimeCardCommand.php
+++ b/src/TempoSimple/Bundle/SpaghettiBundle/Command/PunchTimeCardCommand.php
@@ -46,7 +46,11 @@ class PunchTimeCardCommand extends Command
     /** {@inheritdoc} */
     protected function configure()
     {
-        $startHour = $this->timeCardRepository->findLastOne();
+        try {
+            $startHour = $this->timeCardRepository->findLastOne();
+        } catch (\Exception $e) {
+            $startHour = '09:00';
+        }
 
         $this->setName('tempo-simple:punch:time-card');
         $this->setAliases(array('punch'));

--- a/web/app.php
+++ b/web/app.php
@@ -2,8 +2,7 @@
 
 use Symfony\Component\HttpFoundation\Request;
 
-$loader = require_once __DIR__.'/../app/bootstrap.php.cache';
-
+require_once __DIR__.'/../app/autoload.php';
 require_once __DIR__.'/../app/AppKernel.php';
 
 $kernel = new AppKernel('prod', false);

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -3,10 +3,10 @@
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
 
-$loader = require_once __DIR__.'/../app/bootstrap.php.cache';
-Debug::enable();
-
+require_once __DIR__.'/../app/autoload.php';
 require_once __DIR__.'/../app/AppKernel.php';
+
+Debug::enable();
 
 $kernel = new AppKernel('dev', true);
 $kernel->loadClassCache();


### PR DESCRIPTION
To install TempoSimple, you simply need to get the source and download the dependencies:

```
git clone https://github.com/gnugat/tempo-simple.git
cd tempo-simple
git checkout -t origin/fix/install
composer install
```

You need then to create the database:

```
php app/console doctrine:database:create
php app/console schema
```

Problem is: when launching the console, the following error occurs:

```
[PDOException]                                     
SQLSTATE[42000] [1049] Unknown database 'xxx'
```

This means that currently the user has to manually create the database and schema :/ .
